### PR TITLE
Query using `application/x-www-form-urlencoded`

### DIFF
--- a/influxdb_test.go
+++ b/influxdb_test.go
@@ -746,8 +746,10 @@ func TestClient_Timeout(t *testing.T) {
 	_, err = c.Query(query)
 	if err == nil {
 		t.Fatalf("unexpected success. expected timeout error")
-	} else if !strings.Contains(err.Error(), "request canceled") &&
-		!strings.Contains(err.Error(), "use of closed network connection") {
+		return
+	}
+	if !strings.Contains(err.Error(), "request canceled") &&
+		!strings.Contains(err.Error(), "use of closed network connection") && !strings.Contains(err.Error(), "Timeout") {
 		t.Fatalf("unexpected error. expected 'request canceled' error, got %v", err)
 	}
 }

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -160,13 +160,19 @@ func TestClient_Query(t *testing.T) {
 
 func TestClient_QueryWithRP(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		params := r.URL.Query()
-		if got, exp := params.Get("db"), "db0"; got != exp {
-			t.Errorf("unexpected db query parameter: %s != %s", exp, got)
+		err := r.ParseForm()
+		if err != nil {
+			t.Errorf("failed to parse form data: %v", err)
 		}
-		if got, exp := params.Get("rp"), "rp0"; got != exp {
-			t.Errorf("unexpected rp query parameter: %s != %s", exp, got)
+
+		if got, exp := r.Form.Get("db"), "db0"; got != exp {
+			t.Errorf("unexpected db query parameter: %s != %s", got, exp)
 		}
+
+		if got, exp := r.Form.Get("rp"), "rp0"; got != exp {
+			t.Errorf("unexpected rp query parameter: %s != %s", got, exp)
+		}
+
 		var data Response
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This PR updates the query request to send the URL parameters as part of the body with `application/x-www-form-urlencoded`. This fixes the `414 Request-URI too long` errors that can occur when the InfluxQL query becomes too long.

For more info see:
https://docs.influxdata.com/influxdb/v1/guides/query_data/#query-data-with-influxql