### PR TITLE
Sight 10309

### DIFF
--- a/influxdb.go
+++ b/influxdb.go
@@ -245,7 +245,10 @@ func (c *Client) QueryContext(ctx context.Context, q Query) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		io.Copy(ioutil.Discard, resp.Body) // https://github.com/influxdata/influxdb1-client/issues/58
+		resp.Body.Close()
+	}()
 
 	var response Response
 	if q.Chunked {

--- a/v2/client.go
+++ b/v2/client.go
@@ -119,11 +119,11 @@ func NewHTTPClient(conf HTTPConfig) (Client, error) {
 		return nil, fmt.Errorf("unsupported encoding %s", conf.WriteEncoding)
 	}
 
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: conf.InsecureSkipVerify,
-		},
-		Proxy: conf.Proxy,
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.Proxy = conf.Proxy
+
+	tr.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: conf.InsecureSkipVerify,
 	}
 	if conf.TLSConfig != nil {
 		tr.TLSClientConfig = conf.TLSConfig


### PR DESCRIPTION
This PR updates the http client's transport override to ensure we are utilizing golang's defaults. 